### PR TITLE
WQP-1447 (WMA Jenkins jobs not failing with liquibase errors)

### DIFF
--- a/liquibase/scripts/z1_postgres_liquibase.sh
+++ b/liquibase/scripts/z1_postgres_liquibase.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#!/bin/bash
+# The set -e tells bash to exit immediately if a simple command fails.
+# The set -o pipefail tells bash to set pipeline's return status to status of the last (rightmost) command.
+# Both should be used in scripts meant to be called by Jenkins or another job runner.
+set -e
+set -o pipefail
 
 # postgres to postgres db scripts
 ${LIQUIBASE_HOME}/liquibase \

--- a/liquibase/scripts/z2_nwis_liquibase.sh
+++ b/liquibase/scripts/z2_nwis_liquibase.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#!/bin/bash
+# The set -e tells bash to exit immediately if a simple command fails.
+# The set -o pipefail tells bash to set pipeline's return status to status of the last (rightmost) command.
+# Both should be used in scripts meant to be called by Jenkins or another job runner.
+set -e
+set -o pipefail
 
 # nwis schema scripts
 ${LIQUIBASE_HOME}/liquibase \


### PR DESCRIPTION
  Added 'set -e' and 'set -o pipefail' to the z*.sh scripts, so that the script
will exit with error on any failed called to ${LIQUIBASE_HOME}/liquibase