### PR TITLE
WQP-1592 (Drop "unlogged" keyword from all WQP tables)

### DIFF
--- a/liquibase/changeLogs/nwis/tables/agency/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/agency/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.agency set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.agency set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/altitudeDatum/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/altitudeDatum/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.altitude_datum set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.altitude_datum set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/altitudeMethod/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/altitudeMethod/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.altitude_method set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.altitude_method set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/aqfr/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/aqfr/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.aqfr set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.aqfr set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/aquiferType/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/aquiferType/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.aquifer_type set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.aquifer_type set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/bodyPart/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/bodyPart/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.body_part set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.body_part set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/citMeth/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/citMeth/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.cit_meth set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.cit_meth set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/cooperatorNetworks/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/cooperatorNetworks/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.cooperator_networks set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.cooperator_networks set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/cooperatorNetworksStaging/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/cooperatorNetworksStaging/changeLog.yml
@@ -35,5 +35,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.cooperator_networks_staging set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.cooperator_networks_staging set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/cooperators/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/cooperators/changeLog.yml
@@ -51,5 +51,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.cooperators set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.cooperators set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/cooperatorsStaging/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/cooperatorsStaging/changeLog.yml
@@ -53,5 +53,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.cooperators_staging set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.cooperators_staging set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/country/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/country/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.country set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.country set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/county/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/county/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.county set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.county set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/dataReliability/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/dataReliability/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.data_reliability set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.data_reliability set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/discreteGroundWater/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/discreteGroundWater/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.discrete_ground_water set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.discrete_ground_water set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/discreteGroundWaterAQTS/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/discreteGroundWaterAQTS/changeLog.yml
@@ -36,7 +36,6 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.discrete_ground_water_aQTS set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.discrete_ground_water_aqts set unlogged
 
   - changeSet:
       author: ssoper

--- a/liquibase/changeLogs/nwis/tables/fxd/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/fxd/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.fxd set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.fxd set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/gwLevelAccuracy/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/gwLevelAccuracy/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_accuracy set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_accuracy set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/gwLevelApprovalStatus/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/gwLevelApprovalStatus/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_approval_status set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_approval_status set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/gwLevelDateTimeAccuracy/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/gwLevelDateTimeAccuracy/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_date_time_accuracy set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_date_time_accuracy set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/gwLevelMethod/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/gwLevelMethod/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_method set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_method set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/gwLevelSiteStatus/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/gwLevelSiteStatus/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_site_status set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_site_status set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/gwLevelSource/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/gwLevelSource/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_source set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.gw_level_source set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/gwLevels/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/gwLevels/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.gw_levels set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.gw_levels set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/huc/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/huc/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.huc set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.huc set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/hydCondCd/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/hydCondCd/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.hyd_cond_cd set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.hyd_cond_cd set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/hydEventCd/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/hydEventCd/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.hyd_event_cd set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.hyd_event_cd set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/latLongAccuracy/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/latLongAccuracy/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.lat_long_accuracy set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.lat_long_accuracy set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/latLongDatum/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/latLongDatum/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.lat_long_datum set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.lat_long_datum set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/latLongMethod/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/latLongMethod/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.lat_long_method set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.lat_long_method set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/meth/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/meth/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.meth set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.meth set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/methWithCit/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/methWithCit/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.meth_with_cit set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.meth_with_cit set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/natAqfr/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/natAqfr/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.nat_aqfr set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.nat_aqfr set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/nawqaSites/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/nawqaSites/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.nawqa_sites set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.nawqa_sites set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/nwisDistrictCdsByHost/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/nwisDistrictCdsByHost/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.nwis_district_cds_by_host set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.nwis_district_cds_by_host set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/nwisWqxMediumCd/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/nwisWqxMediumCd/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.nwis_wqx_medium_cd set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.nwis_wqx_medium_cd set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/nwisWqxRptLevCd/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/nwisWqxRptLevCd/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.nwis_wqx_rpt_lev_cd set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.nwis_wqx_rpt_lev_cd set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/parm/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/parm/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.parm set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.parm set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/parmAlias/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/parmAlias/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.parm_alias set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.parm_alias set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/parmMeth/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/parmMeth/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.parm_meth set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.parm_meth set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/protoOrg/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/protoOrg/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.proto_org set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.proto_org set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/qwResult/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/qwResult/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.qw_result set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.qw_result set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/qwSample/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/qwSample/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.qw_sample set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.qw_sample set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/sampleParameter/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/sampleParameter/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.sample_parameter set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.sample_parameter set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/siteTp/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/siteTp/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.site_tp set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.site_tp set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/sitefile/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/sitefile/changeLog.yml
@@ -54,5 +54,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.sitefile set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.sitefile set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/stat/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/stat/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.stat set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.stat set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/state/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/state/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.state set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.state set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/topographicSetting/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/topographicSetting/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.topographic_setting set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.topographic_setting set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/tu/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/tu/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.tu set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.tu set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/valQualCd/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/valQualCd/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.val_qual_cd set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.val_qual_cd set unlogged
 

--- a/liquibase/changeLogs/nwis/tables/wqpNemiNwisCrosswalk/changeLog.yml
+++ b/liquibase/changeLogs/nwis/tables/wqpNemiNwisCrosswalk/changeLog.yml
@@ -36,5 +36,4 @@ databaseChangeLog:
           - expectedResult: "1"
       changes:
         - sql: alter table if exists ${NWIS_SCHEMA_NAME}.wqp_nemi_nwis_crosswalk set logged
-        - rollback: alter table if exists ${NWIS_SCHEMA_NAME}.wqp_nemi_nwis_crosswalk set unlogged
 


### PR DESCRIPTION
   Removed rollback for the set logging changesets.
Because why, why, why do we want to rollback to a
state we are trying to get rid of?